### PR TITLE
Some restructuring and improvements to collision hands

### DIFF
--- a/addons/godot-xr-tools/hands/hand.gd
+++ b/addons/godot-xr-tools/hands/hand.gd
@@ -37,6 +37,8 @@ signal hand_scale_changed(scale)
 ## Last world scale (for scaling hands)
 var _last_world_scale : float = 1.0
 
+var _controller : XRController3D
+
 ## Initial hand transform (from controller) - used for scaling hands
 var _transform : Transform3D
 
@@ -90,6 +92,9 @@ func _ready() -> void:
 	# Save the initial hand transform
 	_transform = transform
 
+	# Find our controller
+	_controller = XRTools.find_xr_ancestor(self, "*", "XRController3D")
+
 	# Find the relevant hand nodes
 	_hand_mesh = _find_child(self, "MeshInstance3D")
 	_animation_player = _find_child(self, "AnimationPlayer")
@@ -116,10 +121,9 @@ func _process(_delta: float) -> void:
 		emit_signal("hand_scale_changed", _last_world_scale)
 
 	# Animate the hand mesh with the controller inputs
-	var controller : XRController3D = get_parent()
-	if controller:
-		var grip : float = controller.get_float(grip_action)
-		var trigger : float = controller.get_float(trigger_action)
+	if _controller:
+		var grip : float = _controller.get_float(grip_action)
+		var trigger : float = _controller.get_float(trigger_action)
 
 		# Allow overriding of grip and trigger
 		if _force_grip >= 0.0: grip = _force_grip

--- a/addons/godot-xr-tools/objects/collision_hand/collision_hand_left.tscn
+++ b/addons/godot-xr-tools/objects/collision_hand/collision_hand_left.tscn
@@ -14,7 +14,3 @@ script = ExtResource("1_81rb2")
 [node name="PalmShape" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.029, -0.051, 0.129)
 shape = SubResource("CapsuleShape3D_152xl")
-
-[node name="HandRemoteTransform3D" type="RemoteTransform3D" parent="."]
-
-[node name="PickupRemoteTransform3D" type="RemoteTransform3D" parent="."]

--- a/addons/godot-xr-tools/objects/collision_hand/collision_hand_right.tscn
+++ b/addons/godot-xr-tools/objects/collision_hand/collision_hand_right.tscn
@@ -14,7 +14,3 @@ script = ExtResource("1_o6lmh")
 [node name="PalmShape" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.029, -0.051, 0.129)
 shape = SubResource("CapsuleShape3D_a4yah")
-
-[node name="HandRemoteTransform3D" type="RemoteTransform3D" parent="."]
-
-[node name="PickupRemoteTransform3D" type="RemoteTransform3D" parent="."]

--- a/scenes/collision_hands_demo/collision_hands_demo.tscn
+++ b/scenes/collision_hands_demo/collision_hands_demo.tscn
@@ -45,38 +45,42 @@ walk_pitch_maximum = 1.2
 [node name="CollisionHandsDemo" instance=ExtResource("1_3253r")]
 script = ExtResource("2_uwwri")
 
-[node name="LeftHand" parent="XROrigin3D" index="1"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
+[node name="CollisionHandLeft" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("14_1k85a")]
+pickable_collision = true
+pickable_weight = true
+g_speed = 10.0
 
-[node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("3_febd4")]
+[node name="LeftHand" parent="XROrigin3D/LeftHand/CollisionHandLeft" index="3" instance=ExtResource("3_febd4")]
 
-[node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("4_a68at")]
+[node name="MovementDirect" parent="XROrigin3D/LeftHand/CollisionHandLeft" index="4" instance=ExtResource("4_a68at")]
 strafe = true
 
-[node name="FunctionPickup" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("5_xgqc6")]
+[node name="FunctionPickup" parent="XROrigin3D/LeftHand/CollisionHandLeft" index="5" instance=ExtResource("5_xgqc6")]
 grab_distance = 0.1
 ranged_angle = 10.0
 
-[node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("6_cqxpi")]
+[node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand/CollisionHandLeft" index="6" instance=ExtResource("6_cqxpi")]
 
-[node name="RightHand" parent="XROrigin3D" index="2"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
+[node name="CollisionHandRight" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("15_q16aj")]
+pickable_collision = true
+pickable_weight = true
+g_speed = 10.0
 
-[node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("7_4bclg")]
+[node name="RightHand" parent="XROrigin3D/RightHand/CollisionHandRight" index="3" instance=ExtResource("7_4bclg")]
 
-[node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("4_a68at")]
+[node name="MovementDirect" parent="XROrigin3D/RightHand/CollisionHandRight" index="4" instance=ExtResource("4_a68at")]
 
-[node name="MovementTurn" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("8_eaqgd")]
+[node name="MovementTurn" parent="XROrigin3D/RightHand/CollisionHandRight" index="5" instance=ExtResource("8_eaqgd")]
 
-[node name="FunctionPickup" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("5_xgqc6")]
+[node name="FunctionPickup" parent="XROrigin3D/RightHand/CollisionHandRight" index="6" instance=ExtResource("5_xgqc6")]
 grab_distance = 0.1
 ranged_angle = 10.0
 
-[node name="FunctionPointer" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("9_6jyeo")]
+[node name="FunctionPointer" parent="XROrigin3D/RightHand/CollisionHandRight" index="7" instance=ExtResource("9_6jyeo")]
 show_laser = 2
 laser_length = 1
 
-[node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("6_cqxpi")]
+[node name="FunctionPoseDetector" parent="XROrigin3D/RightHand/CollisionHandRight" index="8" instance=ExtResource("6_cqxpi")]
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("10_847y2")]
 collision_layer = 0
@@ -85,22 +89,6 @@ collision_layer = 0
 default_surface_audio_type = SubResource("Resource_ppd3h")
 
 [node name="MovementClimb" parent="XROrigin3D" index="5" instance=ExtResource("14_k2eur")]
-
-[node name="CollisionHandLeft" parent="XROrigin3D" index="6" instance=ExtResource("14_1k85a")]
-controller_path = NodePath("../LeftHand")
-_hand_path = NodePath("../LeftHand/LeftHand")
-_pickup_path = NodePath("../LeftHand/FunctionPickup")
-pickable_collision = true
-pickable_weight = true
-g_speed = 10.0
-
-[node name="CollisionHandRight" parent="XROrigin3D" index="7" instance=ExtResource("15_q16aj")]
-controller_path = NodePath("../RightHand")
-_hand_path = NodePath("../RightHand/RightHand")
-_pickup_path = NodePath("../RightHand/FunctionPickup")
-pickable_collision = true
-pickable_weight = true
-g_speed = 10.0
 
 [node name="HolodeckMap" parent="." index="1" instance=ExtResource("16_kkrii")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2)


### PR DESCRIPTION
Ok, this is not finished but the important bits are in.

This changes the structure so the new collision hands node becomes a child of the controller node, and all the functions and hand mesh and all those nodes become child nodes of the collision hands node. 

This removes the need for all the remote transforms (which I forgot to remove the nodes for I just realised, I'll do that in a sec).

There are a few issues introduced that I haven't had time to solve yet:
- The two handed code doesn't look right and I haven't had time to make that work
- The distance check that drops whatever is held is overoptimistic, you can drop the glove by punching the bag and the resulting collision overflow results in the player being thrown to the other end of the room :)
- When the player moves through controller input, the hand isn't repositioned right away because its no longer linked. This is a problem the poke thingy has too.

I'll find some time to fix those issues but if you want to merge this before hand so you can work on it yourself as well let me know.
Also if you don't like this approach, all good too :)